### PR TITLE
Update to Relay 1.2

### DIFF
--- a/dist/buildWatchmanExpression.js
+++ b/dist/buildWatchmanExpression.js
@@ -1,0 +1,9 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = buildWatchExpression;
+function buildWatchExpression(options) {
+  return ['allof', ['type', 'f'], ['anyof', ...options.extensions.map(ext => ['suffix', ext])], ['anyof', ...options.include.map(include => ['match', include, 'wholename'])], ...options.exclude.map(exclude => ['not', ['match', exclude, 'wholename']])];
+}

--- a/dist/getFileFilter.js
+++ b/dist/getFileFilter.js
@@ -16,8 +16,8 @@ var _path2 = _interopRequireDefault(_path);
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function getFileFilter(baseDir) {
-  return filename => {
-    const fullPath = _path2.default.join(baseDir, filename);
+  return file => {
+    const fullPath = _path2.default.join(baseDir, file.relPath);
     const stats = _fs2.default.statSync(fullPath);
 
     if (stats.isFile()) {

--- a/dist/getSchema.js
+++ b/dist/getSchema.js
@@ -26,6 +26,7 @@ function getSchema(schemaPath) {
     source = `
   directive @include(if: Boolean) on FRAGMENT | FIELD
   directive @skip(if: Boolean) on FRAGMENT | FIELD
+
   ${source}
   `;
 
@@ -34,6 +35,7 @@ function getSchema(schemaPath) {
     throw new Error(`
 Error loading schema. Expected the schema to be a .graphql or a .json
 file, describing your GraphQL server's API. Error detail:
+
 ${error.stack}
     `.trim());
   }

--- a/dist/getWriter.js
+++ b/dist/getWriter.js
@@ -22,7 +22,6 @@ function getWriter(baseDir) {
   return (onlyValidate, schema, documents, baseDocuments) => {
     return new _relayCompiler.FileWriter({
       config: {
-        buildCommand: 'relay-compiler-webpack-plugin',
         formatModule: _formatGeneratedModule2.default,
         compilerTransforms: {
           codegenTransforms,

--- a/dist/index.js
+++ b/dist/index.js
@@ -42,6 +42,7 @@ class RelayCompilerWebpackPlugin {
     this.writerConfigs = {
       default: {
         getWriter: (...any) => {},
+        isGeneratedFile: filePath => filePath.endsWith('.js') && filePath.includes('__generated__'),
         parser: 'default'
       }
     };

--- a/dist/index.js
+++ b/dist/index.js
@@ -18,6 +18,10 @@ var _getWriter = require('./getWriter');
 
 var _getWriter2 = _interopRequireDefault(_getWriter);
 
+var _buildWatchmanExpression = require('./buildWatchmanExpression');
+
+var _buildWatchmanExpression2 = _interopRequireDefault(_buildWatchmanExpression);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
@@ -31,7 +35,8 @@ class RelayCompilerWebpackPlugin {
         baseDir: '',
         getFileFilter: _getFileFilter2.default,
         getParser: _relayCompiler.FileIRParser.getParser,
-        getSchema: () => {}
+        getSchema: () => {},
+        watchmanExpression: []
       }
     };
     this.writerConfigs = {
@@ -40,6 +45,7 @@ class RelayCompilerWebpackPlugin {
         parser: 'default'
       }
     };
+    this.reporter = {};
 
     if (!options) {
       throw new Error('You must provide options to RelayCompilerWebpackPlugin.');
@@ -64,8 +70,15 @@ class RelayCompilerWebpackPlugin {
     this.parserConfigs.default.baseDir = options.src;
     this.parserConfigs.default.schema = options.schema;
     this.parserConfigs.default.getSchema = () => (0, _getSchema2.default)(options.schema);
+    this.parserConfigs.default.watchmanExpression = (0, _buildWatchmanExpression2.default)({
+      extensions: ['js'],
+      include: ['**'],
+      exclude: ['**/node_modules/**', '**/__mocks__/**', '**/__tests__/**', '**/__generated__/**']
+    });
 
     this.writerConfigs.default.getWriter = (0, _getWriter2.default)(options.src);
+
+    this.reporter = new _relayCompiler.ConsoleReporter({ verbose: false });
   }
 
   apply(compiler) {
@@ -77,6 +90,7 @@ class RelayCompilerWebpackPlugin {
           const runner = new _relayCompiler.Runner({
             parserConfigs: _this.parserConfigs,
             writerConfigs: _this.writerConfigs,
+            reporter: _this.reporter,
             onlyValidate: false,
             skipPersist: true
           });

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "prepublish": "yarn run flow && yarn run clean && yarn run build"
   },
   "peerDependencies": {
-    "graphql": ">=0.9.0",
-    "relay-compiler": ">=1.1.0",
+    "graphql": ">=0.10.5",
+    "relay-compiler": ">=1.2.0",
     "webpack": ">=2.3.0"
   },
   "devDependencies": {

--- a/src/buildWatchmanExpression.js
+++ b/src/buildWatchmanExpression.js
@@ -1,0 +1,16 @@
+export default function buildWatchExpression(options: {
+  extensions: Array<string>,
+  include: Array<string>,
+  exclude: Array<string>,
+}) {
+  return [
+    'allof',
+    ['type', 'f'],
+    ['anyof', ...options.extensions.map(ext => ['suffix', ext])],
+    [
+      'anyof',
+      ...options.include.map(include => ['match', include, 'wholename']),
+    ],
+    ...options.exclude.map(exclude => ['not', ['match', exclude, 'wholename']]),
+  ];
+}

--- a/src/getFileFilter.js
+++ b/src/getFileFilter.js
@@ -3,9 +3,14 @@
 import fs from 'fs'
 import path from 'path'
 
+type File = {
+  relPath: string,
+  hash: string,
+};
+
 export default function getFileFilter (baseDir: string) {
-  return (filename: string) => {
-    const fullPath = path.join(baseDir, filename)
+  return (file: File) => {
+    const fullPath = path.join(baseDir, file.relPath)
     const stats = fs.statSync(fullPath)
 
     if (stats.isFile()) {

--- a/src/getSchema.js
+++ b/src/getSchema.js
@@ -20,6 +20,7 @@ export default function getSchema(schemaPath: string): GraphQLSchema {
     source = `
   directive @include(if: Boolean) on FRAGMENT | FIELD
   directive @skip(if: Boolean) on FRAGMENT | FIELD
+
   ${source}
   `
 
@@ -28,6 +29,7 @@ export default function getSchema(schemaPath: string): GraphQLSchema {
     throw new Error(`
 Error loading schema. Expected the schema to be a .graphql or a .json
 file, describing your GraphQL server's API. Error detail:
+
 ${error.stack}
     `.trim())
   }

--- a/src/getWriter.js
+++ b/src/getWriter.js
@@ -17,7 +17,6 @@ export default function getWriter (baseDir: string) {
   return (onlyValidate: boolean, schema: GraphQLSchema, documents: Map<string, Object>, baseDocuments: Map<string, Object>) => {
     return new FileWriter({
       config: {
-        buildCommand: 'relay-compiler-webpack-plugin',
         formatModule: formatGeneratedModule,
         compilerTransforms: {
           codegenTransforms,

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import fs from 'fs'
 import getSchema from './getSchema'
 import getFileFilter from './getFileFilter'
 import getWriter from './getWriter'
+import buildWatchmanExpression from './buildWatchmanExpression'
 
 import type { Compiler } from 'webpack'
 
@@ -54,6 +55,16 @@ class RelayCompilerWebpackPlugin {
     this.parserConfigs.default.baseDir = options.src
     this.parserConfigs.default.schema = options.schema
     this.parserConfigs.default.getSchema = () => getSchema(options.schema)
+    this.parserConfigs.default.watchmanExpression = buildWatchmanExpression({
+      extensions: [ 'js' ],
+      include: [ '**' ],
+      exclude: [
+        '**/node_modules/**',
+        '**/__mocks__/**',
+        '**/__tests__/**',
+        '**/__generated__/**',
+      ],
+    })
 
     this.writerConfigs.default.getWriter = getWriter(options.src)
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { Runner, FileIRParser } from 'relay-compiler'
+import { Runner, FileIRParser, ConsoleReporter } from 'relay-compiler'
 import fs from 'fs'
 
 import getSchema from './getSchema'
@@ -56,6 +56,8 @@ class RelayCompilerWebpackPlugin {
     this.parserConfigs.default.getSchema = () => getSchema(options.schema)
 
     this.writerConfigs.default.getWriter = getWriter(options.src)
+
+    this.reporter = new ConsoleReporter({ verbose: false });
   }
 
   apply (compiler: Compiler) {
@@ -64,6 +66,7 @@ class RelayCompilerWebpackPlugin {
         const runner = new Runner({
           parserConfigs: this.parserConfigs,
           writerConfigs: this.writerConfigs,
+          reporter: this.reporter,
           onlyValidate: false,
           skipPersist: true,
         })

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ class RelayCompilerWebpackPlugin {
       getFileFilter,
       getParser: FileIRParser.getParser,
       getSchema: () => {},
+      watchmanExpression: [],
     },
   }
 
@@ -27,6 +28,8 @@ class RelayCompilerWebpackPlugin {
       parser: 'default',
     },
   }
+
+  reporter = {}
 
   constructor (options: {
     schema: string,

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,8 @@ class RelayCompilerWebpackPlugin {
   writerConfigs = {
     default: {
       getWriter: (...any: any) => {},
+      isGeneratedFile: (filePath: string) =>
+        filePath.endsWith('.js') && filePath.includes('__generated__'),
       parser: 'default',
     },
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -773,7 +773,7 @@ babel-traverse@^6.24.1:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-types@6.25.0, babel-types@^6.25.0:
+babel-types@6.25.0, babel-types@^6.19.0, babel-types@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.25.0.tgz#70afb248d5660e5d18f811d91c8303b54134a18e"
   dependencies:
@@ -782,7 +782,7 @@ babel-types@6.25.0, babel-types@^6.25.0:
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babel-types@^6.19.0, babel-types@^6.24.1:
+babel-types@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.24.1.tgz#a136879dc15b3606bda0d90c1fc74304c2ff0975"
   dependencies:
@@ -791,11 +791,11 @@ babel-types@^6.19.0, babel-types@^6.24.1:
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babylon@6.17.3, babylon@^6.17.2:
+babylon@6.17.3, babylon@^6.15.0, babylon@^6.17.2:
   version "6.17.3"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.3.tgz#1327d709950b558f204e5352587fd0290f8d8e48"
 
-babylon@^6.11.0, babylon@^6.15.0:
+babylon@^6.11.0:
   version "6.17.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.0.tgz#37da948878488b9c4e3c4038893fa3314b3fc932"
 


### PR DESCRIPTION
Thanks for your fork. Unfortunately it wasn't working with relay-compiler 1.2. This pull request fixes upcoming issues due to a new API of some compiler modules.

One thing to note is, that your needs to have the same GraphQL version as a dependency as Relay 1.2. Otherwise two different versions of GraphQL may be used. This caused an error, rejecting my schema as not valid. Perhaps we should add that to the docs, because it's quite a nasty error...