### PR TITLE
feat: add a option to allow custom reporters

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -92,7 +92,7 @@ class RelayCompilerWebpackPlugin {
 
     this.writerConfigs.default.getWriter = (0, _getWriter2.default)(options.src);
 
-    this.reporter = new _relayCompiler.ConsoleReporter({ verbose: false });
+    this.reporter = options.reporter ? options.reporter : new _relayCompiler.ConsoleReporter({ verbose: false });
   }
 
   apply(compiler) {

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,7 @@ class RelayCompilerWebpackPlugin {
     include: Array<String>,
     exclude: Array<String>,
     watchman: boolean,
+    reporter: {reportError: (area: string, error: string) => void},
   }) {
     if (!options) {
       throw new Error('You must provide options to RelayCompilerWebpackPlugin.')
@@ -87,7 +88,7 @@ class RelayCompilerWebpackPlugin {
 
     this.writerConfigs.default.getWriter = getWriter(options.src)
 
-    this.reporter = new ConsoleReporter({ verbose: false });
+    this.reporter = options.reporter ? options.reporter : new ConsoleReporter({ verbose: false });
   }
 
   apply (compiler: Compiler) {


### PR DESCRIPTION
I want to be able to throw a error and stop the webpack build when a error occurs with a reporter like this one:

```diff
diff --git a/webpack.config.js b/webpack.config.js
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,7 +76,13 @@ module.exports = {
     }),
     new RelayCompilerWebpackPlugin({
       schema: path.resolve(__dirname, './data/schema.graphql'), // or schema.json
-      src: path.resolve(__dirname, './src')
+      src: path.resolve(__dirname, './src'),
+      reporter: {
+        reportError: (caughtLocation, error) => {
+          error.message = chalk.red(error.message)
+          throw error
+        }
+      }
     })
```

This patch takes in a new optional option `reporter`, defaulting to the `ConsoleReporter`.