### PR TITLE
listen for `compile` event

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -98,29 +98,17 @@ class RelayCompilerWebpackPlugin {
   apply(compiler) {
     var _this = this;
 
-    compiler.plugin('before-compile', (() => {
-      var _ref = _asyncToGenerator(function* (compilationParams, callback) {
-        try {
-          const runner = new _relayCompiler.Runner({
-            parserConfigs: _this.parserConfigs,
-            writerConfigs: _this.writerConfigs,
-            reporter: _this.reporter,
-            onlyValidate: false,
-            skipPersist: true
-          });
-
-          yield runner.compileAll();
-        } catch (error) {
-          callback(error);
-          return;
-        }
-        callback();
+    compiler.plugin('compile', _asyncToGenerator(function* () {
+      const runner = new _relayCompiler.Runner({
+        parserConfigs: _this.parserConfigs,
+        writerConfigs: _this.writerConfigs,
+        reporter: _this.reporter,
+        onlyValidate: false,
+        skipPersist: true
       });
 
-      return function (_x, _x2) {
-        return _ref.apply(this, arguments);
-      };
-    })());
+      yield runner.compileAll();
+    }));
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -92,22 +92,16 @@ class RelayCompilerWebpackPlugin {
   }
 
   apply (compiler: Compiler) {
-    compiler.plugin('before-compile', async (compilationParams, callback) => {
-      try {
-        const runner = new Runner({
-          parserConfigs: this.parserConfigs,
-          writerConfigs: this.writerConfigs,
-          reporter: this.reporter,
-          onlyValidate: false,
-          skipPersist: true,
-        })
+    compiler.plugin('compile', async () => {
+      const runner = new Runner({
+        parserConfigs: this.parserConfigs,
+        writerConfigs: this.writerConfigs,
+        reporter: this.reporter,
+        onlyValidate: false,
+        skipPersist: true,
+      })
 
-        await runner.compileAll()
-      } catch (error) {
-        callback(error)
-        return
-      }
-      callback()
+      await runner.compileAll()
     })
   }
 }


### PR DESCRIPTION
Hey! 👋 

I wanted to lower the number of times this plugin outputs info to the webpack output since it seems to be invoked multiple times when running.

This patch listens for the `compile` event instead of the `before-compile` event resulting in one call to the compiler instead of multiple calls. I'm not 100% sure why that is even after reading the webpack docs 😅 

Here's the output before in a example repo:

```
$ cd examples/relay
$ webpack
Parsed default in 0.00s

Writing default
Writer time: 0.03s [0.03s compiling, 0.00s generating, 0.00s extra]
Unchanged: 0 files
Written default in 0.03s
Parsed default in 0.00s

Writing default
Writer time: 0.00s [0.00s compiling, 0.00s generating, 0.00s extra]
Unchanged: 0 files
Written default in 0.00s
```

And here it is after this patch is applied:

```
$ cd examples/relay
$ webpack
Parsed default in 0.00s

Writing default
Writer time: 0.04s [0.04s compiling, 0.00s generating, 0.00s extra]
Unchanged: 0 files
Written default in 0.06s
```

I might be missing something the differences between the `before-compile` and `compile` events here.