### PR TITLE
Fix Flow errors

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,7 +1,6 @@
 [ignore]
 
 [include]
-<PROJECT_DIR>/src
 
 [libs]
 

--- a/src/getSchema.js
+++ b/src/getSchema.js
@@ -1,5 +1,3 @@
-// @flow
-
 import {
   printSchema,
   buildClientSchema,

--- a/src/getWriter.js
+++ b/src/getWriter.js
@@ -1,5 +1,3 @@
-// @flow
-
 import { FileWriter, IRTransforms } from 'relay-compiler'
 import formatGeneratedModule from 'relay-compiler/lib/formatGeneratedModule'
 import type { Map } from 'immutable'


### PR DESCRIPTION
Not *exactly* fix, but this should make CI green again. There's some flow issues when importing `graphql` package. I think their flow libdefs might be out of date.