### PR TITLE
Update CI node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache:
   yarn: true
 
 node_js:
-  - "iojs"
   - "6"
   - "7"
   - "8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ node_js:
   - "6"
   - "7"
   - "8"
+  - "9"
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh


### PR DESCRIPTION
io.js is current failing in CI. I don't think it's really maintained or worth supporting. This adds Node 9.x to the matrix instead.