### PR TITLE
Verify contextInfo before compiling

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -120,7 +120,7 @@ class RelayCompilerWebpackPlugin {
     compiler.plugin('compilation', (compilation, params) => {
       const compile = this.cachedCompiler()
       params.normalModuleFactory.plugin('before-resolve', (result, callback) => {
-        if (result && result.request.match(/__generated__/)) {
+        if (result && result.contextInfo.issuer && result.request.match(/__generated__/)) {
           const request = path.resolve(path.dirname(result.contextInfo.issuer), result.request)
           compile(result.contextInfo.issuer, request).then(() => {
             callback(null, result)


### PR DESCRIPTION
I had some problems using this plugin in a Next.js project. It seems Next.js generates dynamic Webpack entry points for each "page" resulting in `contextInfo` being empty (`{}`) causing `path.resolve` to throw an `ERR_INVALID_ARG_TYPE` error.

This tiny patch simply makes sure there's an issuer set before attempting to compile.