### PR TITLE
use graphql console reporter with quiet:true option

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -93,18 +93,10 @@ class RelayCompilerWebpackPlugin {
     return _asyncToGenerator(function* () {
       const errors = [];
       try {
-        const reporter = {
-          reportError: function reportError(area, error) {
-            return errors.push(error);
-          },
-          reportTime: function reportTime() {},
-          reportMessage: function reportMessage() {}
-        };
-
         const runner = new _relayCompiler.Runner({
           parserConfigs: _this.parserConfigs,
           writerConfigs: _this.writerConfigs,
-          reporter: reporter,
+          reporter: new _relayCompiler.GraphQLConsoleReporter({ quiet: true }),
           onlyValidate: false,
           skipPersist: true
         });

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { Runner, JSModuleParser } from 'relay-compiler'
+import { Runner, JSModuleParser, GraphQLConsoleReporter } from 'relay-compiler'
 import fs from 'fs'
 import path from 'path'
 
@@ -99,16 +99,10 @@ class RelayCompilerWebpackPlugin {
   async compile (issuer: string, request: string) {
     const errors = []
     try {
-      const reporter: GraphQLReporter = {
-        reportError: (area, error) => errors.push(error),
-        reportTime: () => {},
-        reportMessage: () => {}
-      }
-
       const runner = new Runner({
         parserConfigs: this.parserConfigs,
         writerConfigs: this.writerConfigs,
-        reporter: reporter,
+        reporter: new GraphQLConsoleReporter({quiet: true}),
         onlyValidate: false,
         skipPersist: true
       })


### PR DESCRIPTION
We added a `--quiet` option in https://github.com/facebook/relay/pull/2204 that cleaned up some console logs when the option is supplied.

This patch uses this option to make sure we don't console log when webpack is running.

Fixes: https://github.com/danielholmes/relay-compiler-webpack-plugin/issues/5