### PR TITLE
Set compile string to output language extension

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -52,6 +52,8 @@ class RelayCompilerWebpackPlugin {
 
     _defineProperty(this, "writerConfigs", void 0);
 
+    _defineProperty(this, "languagePlugin", void 0);
+
     if (!options) {
       throw new Error('You must provide options to RelayCompilerWebpackPlugin.');
     }
@@ -93,6 +95,7 @@ class RelayCompilerWebpackPlugin {
       sourceParserName,
       languagePlugin: language
     });
+    this.languagePlugin = language;
   }
 
   createParserConfigs({
@@ -161,7 +164,7 @@ class RelayCompilerWebpackPlugin {
           onlyValidate: false,
           skipPersist: true
         });
-        return runner.compile('js');
+        return runner.compile(_this.languagePlugin.outputExtension);
       } catch (error) {
         errors.push(error);
       }

--- a/src/index.js
+++ b/src/index.js
@@ -36,9 +36,9 @@ class RaiseErrorsReporter {
 }
 
 class RelayCompilerWebpackPlugin {
-  parserConfigs: {}
-
-  writerConfigs: {}
+  parserConfigs: {};
+  writerConfigs: {};
+  languagePlugin: PluginInterface;
 
   constructor (options: {
     schema: string | GraphQLSchema,
@@ -105,6 +105,8 @@ class RelayCompilerWebpackPlugin {
       sourceParserName,
       languagePlugin: language
     })
+
+    this.languagePlugin = language
   }
 
   createParserConfigs ({
@@ -187,7 +189,7 @@ class RelayCompilerWebpackPlugin {
         onlyValidate: false,
         skipPersist: true
       })
-      return runner.compile('js')
+      return runner.compile(this.languagePlugin.outputExtension)
     } catch (error) {
       errors.push(error)
     }

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 
 import { Runner } from 'relay-compiler'
 import RelayLanguagePluginJavaScript from 'relay-compiler/lib/RelayLanguagePluginJavaScript'
+import type { PluginInterface } from 'relay-compiler/lib/RelayLanguagePluginInterface'
 import RelaySourceModuleParser from 'relay-compiler/lib/RelaySourceModuleParser'
 import { DotGraphQLParser } from 'graphql-compiler'
 
@@ -46,7 +47,7 @@ class RelayCompilerWebpackPlugin {
     extensions: Array<string>,
     include: Array<string>,
     exclude: Array<string>,
-    languagePlugin?: Function
+    languagePlugin?: () => PluginInterface
   }) {
     if (!options) {
       throw new Error('You must provide options to RelayCompilerWebpackPlugin.')
@@ -119,7 +120,7 @@ class RelayCompilerWebpackPlugin {
     baseDir: string,
     getParser?: Function,
     sourceParserName: string,
-    languagePlugin: any,
+    languagePlugin: PluginInterface,
     schema: string | GraphQLSchema,
     include: Array<string>,
     exclude: Array<string>,
@@ -161,7 +162,7 @@ class RelayCompilerWebpackPlugin {
   }: {
     baseDir: string,
     sourceParserName: string,
-    languagePlugin: any
+    languagePlugin: PluginInterface
   }) {
     return {
       [languagePlugin.outputExtension]: {


### PR DESCRIPTION
Hey @danielholmes 👋 

I think passing `ts` down to `RelayCompilerRunner.compile` when compiling TypeScript and passing `js` when compiling JavaScript is needed when working with different languages. I had some errors at least when trying to use TypeScript and this fixes it. I also added the flow type for the plugin interface where applicable since I saw that it was currently being typed as `any`.

Ref: #33 