### PR TITLE
chore: upgrade to relay 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "fast-glob": "~3.0.3",
-    "graphql": "14"
+    "graphql": "14.5.6"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.2",
@@ -65,11 +65,11 @@
     "npm-run-all": "^4.1.5",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",
-    "react-relay": "^5.0.0",
-    "relay-compiler": "^5.0.0",
+    "react-relay": "^6.0.0",
+    "relay-compiler": "^6.0.0",
     "rimraf": "^2.6.2",
     "standard": "^14.0.0-0",
-    "webpack": "^4.5.0"
+    "webpack": "^4.40.2"
   },
   "babel": {
     "presets": [
@@ -88,6 +88,9 @@
     ]
   },
   "jest": {
+    "watchPathIgnorePatterns": [
+      "dist/"
+    ],
     "coveragePathIgnorePatterns": [
       "/node_modules/",
       "/test/"

--- a/src/getWriter.js
+++ b/src/getWriter.js
@@ -1,8 +1,7 @@
 // @flow
 
 import type { WriteFilesOptions } from 'relay-compiler'
-import RelayFileWriter from 'relay-compiler/lib/RelayFileWriter'
-import RelayIRTransforms from 'relay-compiler/lib/RelayIRTransforms'
+import { FileWriter, IRTransforms } from 'relay-compiler/lib'
 
 export type WriterConfig = {
   outputDir?: string,
@@ -16,7 +15,7 @@ const {
   printTransforms,
   queryTransforms,
   schemaExtensions
-} = RelayIRTransforms
+} = IRTransforms
 
 export default (languagePlugin: any, config: WriterConfig) => ({
   onlyValidate,
@@ -26,7 +25,7 @@ export default (languagePlugin: any, config: WriterConfig) => ({
   sourceControl,
   reporter
 }: WriteFilesOptions) =>
-  RelayFileWriter.writeAll({
+  FileWriter.writeAll({
     config: {
       customScalars: {},
       ...config,

--- a/test/__snapshots__/normalCase.test.js.snap
+++ b/test/__snapshots__/normalCase.test.js.snap
@@ -252,10 +252,10 @@ export type Home_people = $ReadOnlyArray<{|
   +$refType: Home_people$ref,
 |}>;
 export type Home_people$data = Home_people;
-export type Home_people$key = {
+export type Home_people$key = $ReadOnlyArray<{
   +$data?: Home_people$data,
   +$fragmentRefs: Home_people$ref,
-};
+}>;
 */
 
 
@@ -779,10 +779,10 @@ export type Home_people = $ReadOnlyArray<{|
   +$refType: Home_people$ref,
 |}>;
 export type Home_people$data = Home_people;
-export type Home_people$key = {
+export type Home_people$key = $ReadOnlyArray<{
   +$data?: Home_people$data,
   +$fragmentRefs: Home_people$ref,
-};
+}>;
 */
 
 

--- a/test/normalCase.test.js
+++ b/test/normalCase.test.js
@@ -92,6 +92,10 @@ describe('RelayCompilerWebpackPlugin', () => {
 
     webpack(webpackConfig, (err, stats) => {
       expect(err).toBeFalsy()
+      if (stats.compilation.logging) {
+        expect(stats.compilation.logging.get('RelayCompilerPlugin')).toHaveLength(2)
+      }
+
       expect(stats.compilation.errors).toHaveLength(0)
       expect(stats.compilation.warnings).toHaveLength(0)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -655,14 +655,6 @@
     "@babel/helper-regex" "^7.4.4"
     regexpu-core "^4.5.4"
 
-"@babel/polyfill@^7.0.0":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.4.4.tgz#78801cf3dbe657844eeabf31c1cae3828051e893"
-  integrity sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==
-  dependencies:
-    core-js "^2.6.5"
-    regenerator-runtime "^0.13.2"
-
 "@babel/preset-env@^7.1.0":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.5.5.tgz#bc470b53acaa48df4b8db24a570d6da1fef53c9a"
@@ -2046,7 +2038,7 @@ core-js-compat@^3.1.1:
     browserslist "^4.6.6"
     semver "^6.3.0"
 
-core-js@^2.4.1, core-js@^2.6.5:
+core-js@^2.4.1:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
   integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
@@ -3137,10 +3129,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.1.tgz#1c1f0c364882c868f5bff6512146328336a11b1d"
   integrity sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==
 
-graphql@14:
-  version "14.4.2"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.4.2.tgz#553a7d546d524663eda49ed6df77577be3203ae3"
-  integrity sha512-6uQadiRgnpnSS56hdZUSvFrVcQ6OF9y6wkxJfKquFtHlnl7+KSuWwSJsdwiK1vybm1HgcdbpGkCpvhvsVQ0UZQ==
+graphql@14.5.6:
+  version "14.5.6"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.5.6.tgz#3fa12173b50e6ccdef953c31c82f37c50ef58bec"
+  integrity sha512-zJ6Oz8P1yptV4O4DYXdArSwvmirPetDOBnGFRBl0zQEC68vNW3Ny8qo8VzMgfr+iC8PKiRYJ+f2wub41oDCoQg==
   dependencies:
     iterall "^1.2.2"
 
@@ -5408,15 +5400,15 @@ react-is@^16.8.1, react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
   integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
 
-react-relay@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/react-relay/-/react-relay-5.0.0.tgz#66af68e8e5fad05879a3f21f895a0296ef2741a8"
-  integrity sha512-gpUvedaCaPVPT0nMrTbev2TzrU0atgq2j/zAnGHiR9WgqRXwtHsK6FWFN65HRbopO2DzuJx9VZ2I3VO6uL5EMA==
+react-relay@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/react-relay/-/react-relay-6.0.0.tgz#2a54274a471ef801a465704e58f1db91059ad1d3"
+  integrity sha512-F0UO50TNIyfkTaCnKgbniATIWPpaX0ukQ5QPdaRRwL1qxslx90Umi83XaaiHyy1etKVePMZ+DHCd1aV7yw1AKA==
   dependencies:
     "@babel/runtime" "^7.0.0"
     fbjs "^1.0.0"
     nullthrows "^1.1.0"
-    relay-runtime "5.0.0"
+    relay-runtime "6.0.0"
 
 react@^16.6.3:
   version "16.9.0"
@@ -5556,15 +5548,14 @@ regjsparser@^0.6.0:
   dependencies:
     jsesc "~0.5.0"
 
-relay-compiler@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/relay-compiler/-/relay-compiler-5.0.0.tgz#ca2514bda20ff829550ac87f126d07a1517bf6de"
-  integrity sha512-q8gKlPRTJe/TwtIokbdXehy1SxDFIyLBZdsfg60J4OcqyviIx++Vhc+h4lXzBY8LsBVaJjTuolftYcXJLhlE6g==
+relay-compiler@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/relay-compiler/-/relay-compiler-6.0.0.tgz#a70ecb39b59dea507261aeda704c071326d69d5e"
+  integrity sha512-8K8cCwrOTqu3usF8GXQ+JEgxcTxJ5qVFqfNpfMYrRpMraXrBmykcLRpj38p2MxtcjyqkE2ZnUe5huW5/469obA==
   dependencies:
     "@babel/core" "^7.0.0"
     "@babel/generator" "^7.0.0"
     "@babel/parser" "^7.0.0"
-    "@babel/polyfill" "^7.0.0"
     "@babel/runtime" "^7.0.0"
     "@babel/traverse" "^7.0.0"
     "@babel/types" "^7.0.0"
@@ -5575,14 +5566,14 @@ relay-compiler@^5.0.0:
     fbjs "^1.0.0"
     immutable "~3.7.6"
     nullthrows "^1.1.0"
-    relay-runtime "5.0.0"
+    relay-runtime "6.0.0"
     signedsource "^1.0.0"
     yargs "^9.0.0"
 
-relay-runtime@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-5.0.0.tgz#7c688ee621d6106a2cd9f3a3706eb6d717c7f660"
-  integrity sha512-lrC2CwfpWWHBAN608eENAt5Bc5zqXXE2O9HSo8tc6Gy5TxfK+fU+x9jdwXQ2mXxVPgANYtYeKzU5UTfcX0aDEw==
+relay-runtime@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-6.0.0.tgz#073ec2408f41a28c3a7310d71dd5f42f8e4e4bf3"
+  integrity sha512-zIXQqFfe0zBCVzKbMGEPMvKFxfbE3pY2RbZsKBvHAr/vMDj6OX9E+f4R4udE5xvMbI7g+baYFHi2I9NDEydGaQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
     fbjs "^1.0.0"
@@ -6655,10 +6646,10 @@ webpack-sources@^1.4.0, webpack-sources@^1.4.1:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@^4.5.0:
-  version "4.39.2"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.39.2.tgz#c9aa5c1776d7c309d1b3911764f0288c8c2816aa"
-  integrity sha512-AKgTfz3xPSsEibH00JfZ9sHXGUwIQ6eZ9tLN8+VLzachk1Cw2LVmy+4R7ZiwTa9cZZ15tzySjeMui/UnSCAZhA==
+webpack@^4.40.2:
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.40.2.tgz#d21433d250f900bf0facbabe8f50d585b2dc30a7"
+  integrity sha512-5nIvteTDCUws2DVvP9Qe+JPla7kWPPIDFZv55To7IycHWZ+Z5qBdaBYPyuXWdhggTufZkQwfIK+5rKQTVovm2A==
   dependencies:
     "@webassemblyjs/ast" "1.8.5"
     "@webassemblyjs/helper-module-context" "1.8.5"


### PR DESCRIPTION
partly addresses #46 I deferred making the filesystem changes b/c it's not as straightforward as i'd like. The fs is cached, and `stat`ing early like this plugin does can poison the fs cache so that webpack thinks files don't exist when they do.